### PR TITLE
Set site environment variables in local dev

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -139,6 +139,7 @@ class DevCommand extends Command {
         }
       }
     }
+    process.env.NETLIFY_DEV = 'true'
     let settings = serverSettings()
     if (!(settings && settings.cmd)) {
       this.log('No dev server detected, using simple static server')


### PR DESCRIPTION
We'll want more control over this in the future, especially in terms of
distinguishing between dev context and production context.

For now this is a starting point.

With this change any locally defined environment variable will also take
precendence over any env var set in the site settings or from an addon