### PR TITLE
Fix eslint use-spread error by requiring node 8.3.0 (from 8.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nyc": "^13"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.3.0"
   },
   "files": [
     "/npm-shrinkwrap.json",


### PR DESCRIPTION
The package uses spreads in several places, so this is already true *de facto*. Perhaps the better fix is to remove the spreads - LMK and I'll do so.