### PR TITLE
Fix Gatsby's dev command.

### DIFF
--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -11,7 +11,7 @@ module.exports = function() {
     port: 8888,
     proxyPort: 8000,
     env: { ...process.env },
-    args: yarnExists ? ['run', 'dev'] : ['dev'],
+    args: yarnExists ? ['run', 'develop'] : ['develop'],
     urlRegexp: new RegExp(`(http://)([^:]+:)${8000}(/)?`, 'g'),
     dist: 'public'
   }


### PR DESCRIPTION
The command name is `develop`, not `dev`. `npm run dev` fails
in the most recent stable version of Gatsby because the script doesn't
exist.