### PR TITLE
Add example for [dev] block

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The number of project types which Netlify Dev can detect is growing, but if your
 
 #sample dev block in the toml
 [dev]
-  cmd = "yarn start" # Command to start your dev server
+  command = "yarn start" # Command to start your dev server
   port = 3000 # Port that the dev server will be listening on
   publish = "dist" # Folder with the static content for _redirect file
 ```


### PR DESCRIPTION
This ads an example to the README for the dev block in netlify.toml