### PR TITLE
Use the standard netlify js client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,18 @@
       "resolved": "https://registry.npmjs.org/@netlify/open-api/-/open-api-0.9.0.tgz",
       "integrity": "sha512-9HpbxZX0LnU2IkaIYIjw6GCQZ6JMQ0Ai3F+9RrHr2jMAgXiiHRT19h2CiKEbjv44lYD5a0sRyV6kr+YRJVUQjg=="
     },
+    "@netlify/rules-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@netlify/rules-proxy/-/rules-proxy-0.1.0.tgz",
+      "integrity": "sha512-WhmFkHOb7w1+7v+p+iKmG0jFG8vTWXHVyFxhCSNyC+Aax67BvUS7bMpBk3qnu1i672Af4aupKysdF78ngnDESA==",
+      "requires": {
+        "chokidar": "^2.0.4",
+        "cookie": "^0.3.1",
+        "http-proxy-middleware": "^0.19.1",
+        "netlify-redirect-parser": "^1.0.3",
+        "netlify-redirector": "^0.0.3"
+      }
+    },
     "@netlify/zip-it-and-ship-it": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-0.1.3.tgz",
@@ -3997,17 +4009,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/netlify-redirector/-/netlify-redirector-0.0.3.tgz",
       "integrity": "sha512-D0sOc4PZNXoWJKnIPdy1qmbAa9Lx9qTv5jr8N06+mD3vSgWZhq8ImAjvJvLcdMZB1bpis+VNsYMH0ovR/9U3lg=="
-    },
-    "netlify-rules-proxy": {
-      "version": "git+ssh://git@github.com/netlify/netlify-rules-proxy.git#ad51f81bf5f41619d69e5a28a8dd50ce4649cb82",
-      "from": "git+ssh://git@github.com/netlify/netlify-rules-proxy.git",
-      "requires": {
-        "chokidar": "^2.0.4",
-        "cookie": "^0.3.1",
-        "http-proxy-middleware": "^0.19.1",
-        "netlify-redirect-parser": "^1.0.3",
-        "netlify-redirector": "^0.0.3"
-      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "inquirer": "^6.2.2",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "netlify": "2.4.1",
-    "netlify-rules-proxy": "git+ssh://git@github.com/netlify/netlify-rules-proxy.git",
+    "@netlify/rules-proxy": "0.1.0",
     "node-fetch": "^2.3.0",
     "opn": "^5.5.0",
     "safe-join": "^0.1.2",

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -25,7 +25,7 @@ function addonUrl(addonUrls, req) {
 }
 
 async function startProxy(settings, addonUrls) {
-  const rulesProxy = require('netlify-rules-proxy')
+  const rulesProxy = require('@netlify/rules-proxy')
 
   await waitPort({ port: settings.proxyPort })
   if (settings.functionsPort) {


### PR DESCRIPTION
This changes the netlify dependency to our standard client, since zip-it-and-ship-it is now supported there.