### PR TITLE
refactor cmd to command, document, and make netlify.toml dev block overrides explicit

### DIFF
--- a/src/detectors/README.md
+++ b/src/detectors/README.md
@@ -1,0 +1,23 @@
+## writing a detector
+
+- write as many checks as possible to fit your project
+- return false if its not your project
+- if it definitely is, return an object with this shape:
+
+```ts
+{
+    cmd: String, // e.g. yarn, npm
+    port: Number, // e.g. 8888
+    proxyPort: Number, // e.g. 3000
+    env: Object, // env variables, see examples
+    args: String, // e.g 'run develop', so that the combined command is 'npm run develop'
+    urlRegexp: RegExp, // see examples
+    dist: String // e.g. 'dist' or 'build'
+}
+```
+
+## things to note
+
+- Dev block overrides will supercede anything you write in your detector: https://github.com/netlify/netlify-dev-plugin#project-detection
+- detectors are language agnostic. don't assume npm or yarn.
+- if default args (like 'develop') are missing, that means the user has configured it, best to tell them to use the -c flag.

--- a/src/detectors/cra.js
+++ b/src/detectors/cra.js
@@ -20,7 +20,7 @@ module.exports = function() {
 
   const yarnExists = existsSync('yarn.lock')
   return {
-    cmd: yarnExists ? 'yarn' : 'npm',
+    command: yarnExists ? 'yarn' : 'npm',
     port: 8888,
     proxyPort: 3000,
     env: { ...process.env, BROWSER: 'none', PORT: 3000 },

--- a/src/detectors/eleventy.js
+++ b/src/detectors/eleventy.js
@@ -9,7 +9,7 @@ module.exports = function() {
     port: 8888,
     proxyPort: 8080,
     env: { ...process.env },
-    cmd: 'npx',
+    command: 'npx',
     args: ['eleventy', '--serve', '--watch'],
     urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, 'g'),
     dist: '_site'

--- a/src/detectors/gatsby.js
+++ b/src/detectors/gatsby.js
@@ -7,7 +7,7 @@ module.exports = function() {
 
   const yarnExists = existsSync('yarn.lock')
   return {
-    cmd: yarnExists ? 'yarn' : 'npm',
+    command: yarnExists ? 'yarn' : 'npm',
     port: 8888,
     proxyPort: 8000,
     env: { ...process.env },

--- a/src/detectors/hugo.js
+++ b/src/detectors/hugo.js
@@ -9,7 +9,7 @@ module.exports = function() {
     port: 8888,
     proxyPort: 1313,
     env: { ...process.env },
-    cmd: 'hugo',
+    command: 'hugo',
     args: ['server', '-w'],
     urlRegexp: new RegExp(`(http://)([^:]+:)${1313}(/)?`, 'g'),
     dist: 'public'

--- a/src/detectors/jekyll.js
+++ b/src/detectors/jekyll.js
@@ -9,7 +9,7 @@ module.exports = function() {
     port: 8888,
     proxyPort: 4000,
     env: { ...process.env },
-    cmd: 'bundle',
+    command: 'bundle',
     args: ['exec', 'jekyll', 'serve', '-w', '-l'],
     urlRegexp: new RegExp(`(http://)([^:]+:)${4000}(/)?`, 'g'),
     dist: '_site'

--- a/src/detectors/react-static.js
+++ b/src/detectors/react-static.js
@@ -7,7 +7,7 @@ module.exports = function() {
 
   const yarnExists = existsSync('yarn.lock')
   return {
-    cmd: yarnExists ? 'yarn' : 'npm',
+    command: yarnExists ? 'yarn' : 'npm',
     port: 8888,
     proxyPort: 3000,
     env: { ...process.env },

--- a/src/detectors/vue.js
+++ b/src/detectors/vue.js
@@ -20,7 +20,7 @@ module.exports = function() {
 
   const yarnExists = existsSync('yarn.lock')
   return {
-    cmd: yarnExists ? 'yarn' : 'npm',
+    command: yarnExists ? 'yarn' : 'npm',
     port: 8888,
     proxyPort: 8080,
     env: { ...process.env },


### PR DESCRIPTION
refactor cmd to command, document, and make netlify.toml dev block overrides explicit

in part to help with this: https://github.com/netlify/netlify-dev-plugin/issues/55

but also matches the naming agreed in this https://github.com/netlify/netlify-dev-plugin/pull/44

we will want to extract detectors to a separate repo and that is being tracked in this https://github.com/netlify/netlify-dev-plugin/issues/42