### PR TITLE
Handle alternative paths the same way as when deployed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       "integrity": "sha512-9HpbxZX0LnU2IkaIYIjw6GCQZ6JMQ0Ai3F+9RrHr2jMAgXiiHRT19h2CiKEbjv44lYD5a0sRyV6kr+YRJVUQjg=="
     },
     "@netlify/rules-proxy": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/rules-proxy/-/rules-proxy-0.1.0.tgz",
-      "integrity": "sha512-WhmFkHOb7w1+7v+p+iKmG0jFG8vTWXHVyFxhCSNyC+Aax67BvUS7bMpBk3qnu1i672Af4aupKysdF78ngnDESA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/rules-proxy/-/rules-proxy-0.1.1.tgz",
+      "integrity": "sha512-iPZr6Fuotig5WleOdPGwooZjS9d6A+DlzJLs73a+MM8HghJ/KY4udqpuUVZM7B8mZT05c/Gw7AHZ1ZQzBaIZSw==",
       "requires": {
         "chokidar": "^2.0.4",
         "cookie": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/netlify/netlify-dev-plugin/issues",
   "dependencies": {
     "@netlify/cli-utils": "^1.0.1",
-    "@netlify/rules-proxy": "^0.1.0",
+    "@netlify/rules-proxy": "^0.1.1",
     "@netlify/zip-it-and-ship-it": "^0.1.3",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
This makes sure netlify dev handles .html/.htm/index.html/index.htm paths
the same way our origin server handles these, independently of the underlying
dev servers handling of pretty URLs etc.

This means a request to `/hello` will try to fetch `/hello.html`, `/hello.htm`, `/hello/index.html` and `/hello/index.htm` if `/hello` returns a `404` from the underlying dev server.