### PR TITLE
fix serve functions.. and correct the root cause of localhost:30001 bug

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -146,7 +146,7 @@ class DevCommand extends Command {
     startDevServer(settings, this.log, this.error)
 
     if (functionsDir) {
-      const fnSettings = await serveFunctions({ functionsDir })
+      const fnSettings = await serveFunctions({ ...settings, functionsDir })
       settings.functionsPort = fnSettings.port
     }
 


### PR DESCRIPTION
closes https://github.com/netlify/netlify-dev-plugin/issues/58

this bug was directly caused because ZISI was expecting a full `settings` object: https://github.com/netlify/zip-it-and-ship-it/blob/306d26a4b1ff99bfe0ace291755e980040c2b2ae/src/serve.js#L154

but we were only providing an object with functionsDir: https://github.com/netlify/netlify-dev-plugin/blob/b062da49f63df7599eb2be8e2d6e37ded30f6de1/src/commands/dev/index.js#L149

the indirect fix for this is to use typescript to better communicate & enforce contracts.