### PR TITLE
Fix websocket proxying

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -79,7 +79,8 @@ function initializeProxy(port) {
       req.proxyOptions = options;
       req.alternativePaths = alternativePathsFor(req.url);
       return proxy.web(req, res, options);
-    }
+    },
+    ws: (req, socket, head) => proxy.ws(req, socket, head)
   };
 }
 


### PR DESCRIPTION
The wrapper around the proxy didn't expose the ws method