### PR TITLE
Return a promise from netlify-lambda detector

### DIFF
--- a/src/function-builder-detectors/netlify-lambda.js
+++ b/src/function-builder-detectors/netlify-lambda.js
@@ -33,9 +33,8 @@ module.exports = function() {
   }
 
   if (settings.npmScript) {
-    settings.build = () => {
+    settings.build = () =>
       execa(yarnExists ? "yarn" : "npm", ["run", settings.npmScript]);
-    };
     return settings;
   }
 };


### PR DESCRIPTION
This makes sure we wait for the initial build before starting function server,
so the function folder gets created correctly first