### PR TITLE
fix: Making sure command is properly set in settings from dev block 

### DIFF
--- a/src/detect-server.js
+++ b/src/detect-server.js
@@ -91,12 +91,12 @@ module.exports.serverSettings = async devConfig => {
     settings = settings || {};
     if (devConfig.command) {
       settings.command = assignLoudly(
-        devConfig.command,
-        settings.command.split(/\s/)[0]
+        devConfig.command.split(/\s/)[0],
+        settings.command
       );
       settings.args = assignLoudly(
-        devConfig.command,
-        settings.command.split(/\s/).slice(1)
+        devConfig.command.split(/\s/).slice(1),
+        settings.command
       );
     }
     if (devConfig.port) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Netlify dev would abort when a command was set in the dev block section of the netlify toml.

**- Test plan**
Add a command to the dev block and make sure that netlify dev runs as expected.

**- Description for the changelog**
Made sure settings were set properly.

**- A picture of a cute animal**
![dogBurrito](https://user-images.githubusercontent.com/3229484/55748648-2bf40d80-5a0d-11e9-8031-44c0780edb80.gif)
