### PR TITLE
Add vuepress detector

### DIFF
--- a/src/detectors/vuepress.js
+++ b/src/detectors/vuepress.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["vuepress"])) return false;
+
+  /** everything below now assumes that we are within vue */
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["docs:dev", "dev", "run"],
+    preferredCommand: "vuepress dev"
+  });
+
+  if (!possibleArgsArrs.length) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(["vuepress", "dev"]);
+  }
+
+  return {
+    type: "vuepress",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 8080,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, "g"),
+    dist: ".vuepress/dist"
+  };
+};


### PR DESCRIPTION
**- Summary**
Running `netlify dev` doesn't work for vuepress projects. This fix adds a detector so that the dev server can run. 

**- Test plan**

Add vuepress to your project
```
# install as a local dependency
yarn add -D vuepress # OR npm install -D vuepress

# create a docs directory
mkdir docs
# create a markdown file
echo '# Hello VuePress' > docs/README.md
```

Then update your package.json file so it has the proper command for running vuepress. 
```
{
  "scripts": {
    "dev": "yarn run docs:dev",
  }
}
```
Try running `netlify dev`. You should have a netlify dev server accessible at localhost:8888

**- Description for the changelog**
Adds Vuepress to the list of detectors

**- A picture of a cute animal**
![monkeyInASwing](https://user-images.githubusercontent.com/3229484/55831813-0422a980-5ae2-11e9-8890-b85c80158c7b.gif)
