### PR TITLE
fix npm run bug with execa

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -156,7 +156,9 @@ function startDevServer(settings, log, error) {
     return;
   }
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.type}`);
-  const ps = execa(settings.command, settings.args, {
+  const args =
+    settings.command === "npm" ? ["run", ...settings.args] : settings.args;
+  const ps = execa(settings.command, args, {
     env: settings.env,
     stdio: "inherit"
   });
@@ -167,7 +169,7 @@ function startDevServer(settings, log, error) {
 
 class DevCommand extends Command {
   async run() {
-    this.log(`${NETLIFYDEV} Starting...`);
+    this.log(`${NETLIFYDEV}`);
     let { flags } = this.parse(DevCommand);
     const { api, site, config } = this.netlify;
     const functionsDir =

--- a/src/detectors/utils/jsdetect.js
+++ b/src/detectors/utils/jsdetect.js
@@ -25,7 +25,7 @@ function getYarnOrNPMCommand() {
   if (!yarnExists) {
     yarnExists = existsSync("yarn.lock") ? "yes" : "no";
   }
-  return yarnExists === "yes" ? "yarn" : "npm run";
+  return yarnExists === "yes" ? "yarn" : "npm";
 }
 
 /**


### PR DESCRIPTION

**- Summary**

i had a misunderstanding of how execa works. need to supply "npm" to its "command", not "npm run", or it just dies.

fixes https://github.com/netlify/netlify-dev-plugin/issues/110

