### PR TITLE
fix: Add Nuxt

### DIFF
--- a/src/detectors/nuxt.js
+++ b/src/detectors/nuxt.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["nuxt"])) return false;
+
+  /** everything below now assumes that we are within vue */
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["start", "dev", "run"],
+    preferredCommand: "nuxt start"
+  });
+
+  if (!possibleArgsArrs.length) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(["nuxt", "start"]);
+  }
+
+  return {
+    type: "yarn",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 3000,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, "g"),
+    dist: ".nuxt"
+  };
+};


### PR DESCRIPTION
**- Summary**
@lunaceee and I paired yesterday and realized that a couple of Vue specific SSGs were not yet supported, including Nuxt and Vuepress (which has since been merged, yay!). This PR adds Nuxt to the SSG detectors so it builds properly.

**- Test plan**
```
yarn create nuxt-app <project-name>
cd <project-name>
netlify dev
```

**- Description for the changelog**
Adds Nuxt detector

**- A picture of a cute animal**
![whack-a-finger](https://user-images.githubusercontent.com/3229484/55897150-f591cc00-5b8d-11e9-902a-c0820a3af833.gif)