### PR TITLE
Chalk was not defined

### DIFF
--- a/src/live-tunnel.js
+++ b/src/live-tunnel.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 const execa = require("execa");
+const chalk = require("chalk");
 const { fetchLatest, updateAvailable } = require("gh-release-fetch");
 const { NETLIFYDEVLOG, NETLIFYDEVWARN, NETLIFYDEVERR } = require("./cli-logo");
 


### PR DESCRIPTION
Or if you want to require it only near the console log statement.

**- Summary**
Chalk was not defined

**- Test plan**
Let's migrate to typescript 😅 

**- Description for the changelog**
Now logs correctly if you have not run `netlify init`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5094296/55914196-26144d00-5c04-11e9-841b-d61ed7446cf4.png)
