### PR TITLE
Handle binary request body using buffer: intends to fix #143

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -177,14 +177,13 @@ function createHandler(dir) {
     var isBase64Encoded = false;
     var body = request.body;
 
-    if (body === undefined || Object.keys(body).length === 0) {
-      // handle empty body (https://github.com/expressjs/body-parser/issues/288)
-      body = "";
-    } else if (body instanceof Buffer) {
+    if (body instanceof Buffer) {
       isBase64Encoded = true;
       body = body.toString("base64");
     } else if(typeof(body) === "string") {
       // body is already processed as string
+    } else {
+      body = "";
     }
 
     const lambdaRequest = {

--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -177,12 +177,14 @@ function createHandler(dir) {
     var isBase64Encoded = false;
     var body = request.body;
 
-    if (body instanceof Buffer) {
+    if (body === undefined || Object.keys(body).length === 0) {
+      // handle empty body (https://github.com/expressjs/body-parser/issues/288)
+      body = "";
+    } else if (body instanceof Buffer) {
       isBase64Encoded = true;
       body = body.toString("base64");
-    } else if(body.toString) {
-      isBase64Encoded = false;
-      body = body.toString();
+    } else if(typeof(body) === "string") {
+      // body is already processed as string
     }
 
     const lambdaRequest = {


### PR DESCRIPTION
**- Summary**

Binary bodies where mangled by utf-8 encoding. Now we try to use the bodyParser.raw for binary and bodyParser.text for textual content.

**- Test plan**

My tests are mainly the actions described in issue #143.

**- Description for the changelog**

handle binary request body using buffer

**- A picture of a cute animal (not mandatory but encouraged)**

https://www.youtube.com/watch?v=BjkuMFZBJ3k