### PR TITLE
Fix live tunnel port when proxyPort is taken

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -133,7 +133,7 @@ async function startProxy(settings, addonUrls) {
   });
 
   server.listen(port);
-  return `http://localhost:${port}`;
+  return { url: `http://localhost:${port}`, port };
 }
 
 function startDevServer(settings, log) {
@@ -217,8 +217,6 @@ class DevCommand extends Command {
       };
     }
 
-    let url;
-
     startDevServer(settings, this.log);
 
     // serve functions from zip-it-and-ship-it
@@ -243,18 +241,18 @@ class DevCommand extends Command {
       settings.functionsPort = functionsPort;
     }
 
-    const proxyUrl = await startProxy(settings, addonUrls);
+    let { url, port } = await startProxy(settings, addonUrls);
     if (!url) {
       url = proxyUrl;
     }
 
     if (flags.live) {
-      await waitPort({ port: settings.proxyPort });
+      await waitPort({ port });
       const liveSession = await createTunnel(site.id, accessToken, this.log);
       url = liveSession.session_url;
       process.env.BASE_URL = url;
 
-      await connectTunnel(liveSession, accessToken, settings.port, this.log);
+      await connectTunnel(liveSession, accessToken, port, this.log);
     }
 
     // Todo hoist this telemetry `command` to CLI hook


### PR DESCRIPTION
When starting the proxy we first check if proxyPort is free and otherwise we pick a random free port.

The live tunnel would always connect to the port specified in the settings, so in that case it would
start serving the wrong dev server on the .live domain.

This makes sure we pass on the new port to the live tunnel if changed