### PR TITLE
feat: Add detectors for Quasar v0.17 & v1.0 beta

### DIFF
--- a/src/detectors/quasar-v0.17.js
+++ b/src/detectors/quasar-v0.17.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["quasar-cli"])) return false;
+
+  /** everything below now assumes that we are within Quasar */
+  
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["serve", "start", "run", "dev"],
+    preferredCommand: "quasar dev"
+  });
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup!
+    possibleArgsArrs.push(["quasar", "dev"]);
+  }
+
+  return {
+    type: "quasar-cli-v0.17",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 8080,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, "g"),
+    dist: ".quasar"
+  };
+};

--- a/src/detectors/quasar.js
+++ b/src/detectors/quasar.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["@quasar/app"])) return false;
+
+  /** everything below now assumes that we are within Quasar */
+  
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["serve", "start", "run", "dev"],
+    preferredCommand: "quasar dev"
+  });
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup!
+    possibleArgsArrs.push(["quasar", "dev"]);
+  }
+
+  return {
+    type: "quasar-cli",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 8080,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${8080}(/)?`, "g"),
+    dist: ".quasar"
+  };
+};


### PR DESCRIPTION
Since Quasar is in beta for v1.0 and has some differences this adds a detector for the latest pre-beta & v1.0 beta.