### PR TITLE
Fix dev command when running with npm - fix #119

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -155,9 +155,7 @@ function startDevServer(settings, log) {
     return;
   }
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.type}`);
-  const args =
-    settings.command === "npm" ? ["run", ...settings.args] : settings.args;
-  const ps = execa(settings.command, args, {
+  const ps = execa(settings.command, settings.args, {
     env: settings.env,
     stdio: "inherit"
   });

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -155,7 +155,9 @@ function startDevServer(settings, log) {
     return;
   }
   log(`${NETLIFYDEVLOG} Starting Netlify Dev with ${settings.type}`);
-  const ps = execa(settings.command, settings.args, {
+  const args =
+    settings.command === "npm" ? ["run", ...settings.args] : settings.args;
+  const ps = execa(settings.command, args, {
     env: settings.env,
     stdio: "inherit"
   });

--- a/src/detect-server.js
+++ b/src/detect-server.js
@@ -110,8 +110,10 @@ module.exports.serverSettings = async devConfig => {
         settings.command || null,
         tellUser("command")
       ); // if settings.command is empty, its bc no settings matched
+      let devConfigArgs = devConfig.command.split(/\s/).slice(1);
+      if (devConfigArgs[0] === "run") devConfigArgs = devConfigArgs.slice(1);
       settings.args = assignLoudly(
-        devConfig.command.split(/\s/).slice(1),
+        devConfigArgs,
         settings.command || null,
         tellUser("command")
       ); // if settings.command is empty, its bc no settings matched


### PR DESCRIPTION
**Make defining npm scripts other than `start` possible in dev command**

The behavior was already described in #119. When using npm and defining configuring another command than `npm start` in the `command` field the script execution fails. This is because currently the command get's inserted an additional `run` argument when npm was detected. 

Exception:

```
Waiting for localhost:7894.npm ERR! missing script: run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sjudis/.npm/_logs/2019-05-03T19_11_15_952Z-debug.log

FAIL: 1
```

I believe that it'd be better to always pass the arguments through to execution because this is what users are used to from the build section of the `netlify.toml`.

**- Test plan**

To test this I added a `netlify.toml` file to this repo as follows.

```
# example netlify.toml
[dev]
  command = "npm run version"
  port = 7894
```

Running `$ ./bin/run dev` leads then to the exception because it's running `npm run run version`.

```
🐧  ➡ ./bin/run dev                                                                   [21:10:54]
◈ Netlify Dev ◈
◈ Starting Netlify Dev with undefined
Waiting for localhost:7894.npm ERR! missing script: run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sjudis/.npm/_logs/2019-05-03T19_11_15_952Z-debug.log

FAIL: 1
```

After my changes, the command succeeds.

**- Description for the changelog**

- Fix npm scripts in dev command

**- A picture of a cute animal (not mandatory but encouraged)**
![duck](https://user-images.githubusercontent.com/962099/57160397-ef87b780-6de8-11e9-98d2-272ceaa0c440.gif)
