### PR TITLE
Use `existsSync` instead of `hasRequiredFiles` (fixes #177)

### DIFF
--- a/src/detectors/middleman.js
+++ b/src/detectors/middleman.js
@@ -1,7 +1,9 @@
 const { existsSync } = require("fs");
 
 module.exports = function() {
-  if (!hasRequiredFiles(["config.rb"])) return false;
+  if (!existsSync("config.rb")) {
+    return false;
+  }
 
   return {
     type: "middleman",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This PR fixes issue #177, an error in the Middleman detector added in #172.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

Running `npm test` in the project's root folder throws a bunch of unrelated errors, but… the change here mimics other detectors in this repo (especially the `jekyll.js` detector.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Change uses the existing `existsSync` imported function rather than the unimported `hasRequiredFiles` that was throwing the errors reported in #177.

**- A picture of a cute animal (not mandatory but encouraged)**

![Corgi in a sweater](https://blog.corgithings.com/wp-content/uploads/2017/04/AutumnTopi.gif)