### PR TITLE
Add a hook command to netlify-dev

### DIFF
--- a/src/commands/dev/hook.js
+++ b/src/commands/dev/hook.js
@@ -1,0 +1,65 @@
+const execa = require("execa");
+const Command = require("@netlify/cli-utils");
+const { track } = require("@netlify/cli-utils/src/utils/telemetry");
+const {
+  // NETLIFYDEV,
+  NETLIFYDEVLOG,
+  // NETLIFYDEVWARN,
+  NETLIFYDEVERR
+} = require("netlify-cli-logo");
+
+class HookCommand extends Command {
+  async run() {
+    const { site, api, config } = this.netlify;
+
+    if (!(config && config.dev && config.dev.hooks)) {
+      this.log(`${NETLIFYDEVERR} No hooks defined in your netlify.toml.`);
+      process.exit(1);
+    }
+
+    if (site.id) {
+      this.log(
+        `${NETLIFYDEVLOG} Checking your site's environment variables...`
+      ); // just to show some visual response first
+      const accessToken = api.accessToken;
+      const { addEnvVariables } = require("../../utils/dev");
+      await addEnvVariables(api, site, accessToken);
+    } else {
+      this.log(
+        `${NETLIFYDEVERR} No Site ID detected. You probably forgot to run \`netlify link\` or \`netlify init\`. `
+      );
+    }
+
+    const hook = this.argv.join(" ");
+    const cmd = config.dev.hooks[hook];
+
+    if (!cmd) {
+      this.log(
+        `${NETLIFYDEVERR} No hook called "${hook}" defined in your netlify.toml.`
+      );
+      process.exit(1);
+    }
+
+    execa(cmd.split(" ")[0], cmd.split(" ").slice(1), {
+      env: process.env,
+      stdio: "inherit"
+    });
+    // Todo hoist this telemetry `command` to CLI hook
+    track("command", {
+      command: "dev:hook"
+    });
+  }
+}
+
+HookCommand.description = `Hook command
+Responds to one of the named hook defined in your netlify.toml file.
+Used with \`netlify dev --live\` to handle updates on webhooks triggered
+by external systems like Contentful, Sanity, etc...
+`;
+
+HookCommand.examples = ["$ netlify hook Contentful"];
+
+HookCommand.strict = false;
+HookCommand.parse = false;
+
+module.exports = HookCommand;


### PR DESCRIPTION
**- Summary**

Add a `netlify dev:hook <Hook Name>` command

**- Test plan**

Projects with a `[dev.hooks]` setting in their `netlify.toml` file will be able to trigger the commands
specified in those hooks via `netlify dev:hook <Hook Name>`

As an example, a section like this in the `netlify.toml` file:

```
[dev.hooks]
  Contentful = "npm run fetch-contentful-data"
```

Would define a hook that can be triggered via `netlify dev:hook Contentful` to refetch data.

Once we have this feature in place and testable in `netlify dev`, we can tie it into Netlify's general inbound webhook system and allow `netlify dev` to listen for inbound hooks so the dev server rebuilds on external data source changes. Especially useful with `netlify dev --live`

**- Description for the changelog**

Add a `netlify dev:hook <Hook Name>` command

**- A picture of a cute animal (not mandatory but encouraged)**

![main-qimg-79c4206d7b80619b39a92b1efe296ed3](https://user-images.githubusercontent.com/6515/57986779-0c013200-7a2e-11e9-9f9f-02de53f40664.png)

