### PR TITLE
Make port and dir flag available

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -191,6 +191,7 @@ class DevCommand extends Command {
         `${NETLIFYDEVWARN} No dev server detected, using simple static server`
       );
       let dist =
+        flags.dir ||
         (config.dev && config.dev.publish) ||
         (config.build && config.build.publish);
       if (!dist) {
@@ -211,7 +212,7 @@ class DevCommand extends Command {
       }
       settings = {
         noCmd: true,
-        port: 8888,
+        port: flags.port || 8888,
         proxyPort: 3999,
         dist
       };
@@ -296,7 +297,7 @@ DevCommand.strict = false;
 DevCommand.flags = {
   command: flags.string({ char: "c", description: "command to run" }),
   port: flags.integer({ char: "p", description: "port of netlify dev" }),
-  dir: flags.integer({ char: "d", description: "dir with static files" }),
+  dir: flags.string({ char: "d", description: "dir with static files" }),
   functions: flags.string({
     char: "f",
     description: "Specify a functions folder to serve"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Same as title.

- Fix type of 'dir' option
- Use flags.dir / flags.port in application

I wanted to change port & dir. I found its option in netlify cli, but it didn't works.

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

0. Use --dir= and --port= option in your local environment without netlify.toml.
0. With `--dir=` option, it's successful if you can't see the message from L198.
0. WIth `--port=` option, it's successful if you can see `Server now ready on http://localhost:${your port}` message.

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**

Make port and dir flag available

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![cat-typing](https://user-images.githubusercontent.com/15062473/58644837-10d2b980-833d-11e9-9400-1298c394679b.gif)
