### PR TITLE
Check if functions directory exists. Fixes #182

### DIFF
--- a/src/utils/serve-functions.js
+++ b/src/utils/serve-functions.js
@@ -56,27 +56,29 @@ function buildClientContext(headers) {
 
 function createHandler(dir) {
   const functions = {};
-  fs.readdirSync(dir).forEach(file => {
-    if (dir === "node_modules") {
-      return;
-    }
-    const functionPath = path.resolve(path.join(dir, file));
-    const handlerPath = findHandler(functionPath);
-    if (!handlerPath) {
-      return;
-    }
-    if (path.extname(functionPath) === ".js") {
-      functions[file.replace(/\.js$/, "")] = {
-        functionPath,
-        moduleDir: findModuleDir(functionPath)
-      };
-    } else if (fs.lstatSync(functionPath).isDirectory()) {
-      functions[file] = {
-        functionPath: handlerPath,
-        moduleDir: findModuleDir(functionPath)
-      };
-    }
-  });
+  if (fs.existsSync(dir)) {
+    fs.readdirSync(dir).forEach(file => {
+      if (dir === "node_modules") {
+        return;
+      }
+      const functionPath = path.resolve(path.join(dir, file));
+      const handlerPath = findHandler(functionPath);
+      if (!handlerPath) {
+        return;
+      }
+      if (path.extname(functionPath) === ".js") {
+        functions[file.replace(/\.js$/, "")] = {
+          functionPath,
+          moduleDir: findModuleDir(functionPath)
+        };
+      } else if (fs.lstatSync(functionPath).isDirectory()) {
+        functions[file] = {
+          functionPath: handlerPath,
+          moduleDir: findModuleDir(functionPath)
+        };
+      }
+    });
+  }
 
   const clearCache = action => path => {
     console.log(`${NETLIFYDEVLOG} ${path} ${action}, reloading...`); // eslint-disable-line no-console


### PR DESCRIPTION
**- Summary**

`netlify dev --live` fails to start if the functions directory doesn't exist.

Given the fact that `netlify init` doesn't create functions directory by default, the first-time experience of netlify dev is 😔

**- Test plan**
1. Init a project with netlify init
2. Try running `netlify dev --live`

**- Description for the changelog**

Don't assume functions directory, check if it exists.