### PR TITLE
Add svelte and sapper to list of detectors

### DIFF
--- a/src/detectors/sapper.js
+++ b/src/detectors/sapper.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["sapper"])) return false;
+
+  /** everything below now assumes that we are within vue */
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["dev", "start"],
+    preferredCommand: "sapper dev"
+  });
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(["sapper", "dev"]);
+  }
+
+  return {
+    type: "vue-cli",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 3000,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${3000}(/)?`, "g"),
+    dist: "dist"
+  };
+};

--- a/src/detectors/svelte.js
+++ b/src/detectors/svelte.js
@@ -1,0 +1,36 @@
+const {
+  hasRequiredDeps,
+  hasRequiredFiles,
+  getYarnOrNPMCommand,
+  scanScripts
+} = require("./utils/jsdetect");
+
+module.exports = function() {
+  // REQUIRED FILES
+  if (!hasRequiredFiles(["package.json"])) return false;
+  // REQUIRED DEPS
+  if (!hasRequiredDeps(["svelte"])) return false;
+
+  /** everything below now assumes that we are within vue */
+
+  const possibleArgsArrs = scanScripts({
+    preferredScriptsArr: ["dev", "start", "run"],
+    preferredCommand: "npm run dev"
+  });
+
+  if (possibleArgsArrs.length === 0) {
+    // ofer to run it when the user doesnt have any scripts setup! 🤯
+    possibleArgsArrs.push(["npm", "dev"]);
+  }
+
+  return {
+    type: "svelte",
+    command: getYarnOrNPMCommand(),
+    port: 8888,
+    proxyPort: 5000,
+    env: { ...process.env },
+    possibleArgsArrs,
+    urlRegexp: new RegExp(`(http://)([^:]+:)${5000}(/)?`, "g"),
+    dist: "dist"
+  };
+};


### PR DESCRIPTION
**- Summary**
Now that Svelte 3 is out, we should support svelte projects on Netlify Dev 

**- Test plan**
Run an example svelte project. 

Sapper:
```
npx degit "sveltejs/sapper-template#rollup" my-app
cd my-app
netlify dev
```

Svelte: 
```
npx degit sveltejs/template my-svelte-project
cd my-svelte-project
netlify dev
```

**- Description for the changelog**
Adds Svelte and Sapper to list of detectors

**- A picture of a cute animal (not mandatory but encouraged)**
![elfoDance](https://user-images.githubusercontent.com/3229484/59465623-4e354d80-8df9-11e9-80ae-12e84f48d5c0.gif)
