### PR TITLE
Make ports for local server dynamic

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -212,8 +212,16 @@ class DevCommand extends Command {
       settings = {
         noCmd: true,
         port: 8888,
-        proxyPort: 3999,
+        proxyPort: await getPort({ port: 3999 }),
         dist
+      };
+    }
+
+    // Reset port if not manually specified, to make it dynamic
+    if (!(config.dev && config.dev.port)) {
+      settings = {
+        port: await getPort({ port: settings.port }),
+        ...settings
       };
     }
 

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -218,7 +218,7 @@ class DevCommand extends Command {
     }
 
     // Reset port if not manually specified, to make it dynamic
-    if (!(config.dev && config.dev.port)) {
+    if (!(config.dev && config.dev.port) && !flags.port) {
       settings = {
         port: await getPort({ port: settings.port }),
         ...settings


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Allow the user to run more than one dev server at one time.

**- Test plan**

* Run `netlify dev` in your project directory
* Run `netlify dev` in a different project directory

**- Description for the changelog**

For the static server, we have moved from the absolute `proxyPort: 3999` to `getPort` method that chooses an available port.
For the `8888` server port, we use dynamic port from `getPort` if the user hasn't specified `port` in their `config`.

**- A picture of a cute animal (not mandatory but encouraged)**
![rusty-spotted-cat-kitten](https://user-images.githubusercontent.com/10067728/60448643-79180200-9c3f-11e9-993f-8f508e185144.jpg)
