### PR TITLE
fix typo

### DIFF
--- a/src/functions-templates/js/send-email/.netlify-function-template.js
+++ b/src/functions-templates/js/send-email/.netlify-function-template.js
@@ -1,4 +1,4 @@
 module.exports = {
   name: "send-email",
-  description: "Send Email: Send email with no STMP server via 'sendmail' pkg"
+  description: "Send Email: Send email with no SMTP server via 'sendmail' pkg"
 };

--- a/src/functions-templates/js/send-email/package.json
+++ b/src/functions-templates/js/send-email/package.json
@@ -1,7 +1,7 @@
 {
   "name": "send-email",
   "version": "1.0.0",
-  "description": "netlify functions:create - Send email with no STMP server via 'sendmail' pkg",
+  "description": "netlify functions:create - Send email with no SMTP server via 'sendmail' pkg",
   "main": "send-email.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
**- Summary**

Was using `ntl functions:create` to scaffold a new lambda and noticed that SMTP is spelled STMP. 

**- Description for the changelog**

Fix typo in send-email function.

Cheers

![cheers](https://pbs.twimg.com/media/DyKs6m8XcAYfIM7.jpg)
