### PR TITLE
warn before running function builder

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -232,6 +232,13 @@ class DevCommand extends Command {
     if (functionsDir) {
       const functionBuilder = await detectFunctionsBuilder(settings);
       if (functionBuilder) {
+        this.log(
+          `running npm script ${chalk.yellow(
+            functionBuilder.npmScript
+          )} with detected function builder ${chalk.yellow(
+            functionBuilder.builderName
+          )}`
+        );
         await functionBuilder.build();
         const functionWatcher = chokidar.watch(functionBuilder.src);
         functionWatcher.on("add", functionBuilder.build);

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -233,11 +233,14 @@ class DevCommand extends Command {
       const functionBuilder = await detectFunctionsBuilder(settings);
       if (functionBuilder) {
         this.log(
-          `running npm script ${chalk.yellow(
-            functionBuilder.npmScript
-          )} with detected function builder ${chalk.yellow(
+          `${NETLIFYDEVLOG} Function builder ${chalk.yellow(
             functionBuilder.builderName
+          )} detected: Running npm script ${chalk.yellow(
+            functionBuilder.npmScript
           )}`
+        );
+        this.warn(
+          `${NETLIFYDEVWARN} This is a beta feature, please give us feedback on how to improve at https://github.com/netlify/netlify-dev-plugin/`
         );
         await functionBuilder.build();
         const functionWatcher = chokidar.watch(functionBuilder.src);

--- a/src/function-builder-detectors/netlify-lambda.js
+++ b/src/function-builder-detectors/netlify-lambda.js
@@ -35,6 +35,7 @@ module.exports = function() {
   if (settings.npmScript) {
     settings.build = () =>
       execa(yarnExists ? "yarn" : "npm", ["run", settings.npmScript]);
+    settings.builderName = "netlify-lambda";
     return settings;
   }
 };


### PR DESCRIPTION

**- Summary**

i was running into user confusion because i had a fully specified netlify dev block but it still looked like i was using the netlify project detection when it should have skipped all that:

![image](https://user-images.githubusercontent.com/6764957/60991631-e3eccb80-a318-11e9-99f9-020c8f5fbd60.png)

in reality what was happening was that it was a funciton buidler running unintentionally. this is magic and the least we can do is tell people we're doing it so they can yell at us.

**- Description for the changelog**

warn before running function builder



**- A picture of a cute animal (not mandatory but encouraged)**
https://imgur.com/Inbn1BR