### PR TITLE
Don't allow child scripts to manipulate terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "resolve": "^1.10.0",
     "safe-join": "^0.1.2",
     "static-server": "^2.2.1",
+    "strip-ansi": "^5.2.0",
     "wait-port": "^0.2.2",
     "wrap-ansi": "^5.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "resolve": "^1.10.0",
     "safe-join": "^0.1.2",
     "static-server": "^2.2.1",
-    "strip-ansi": "^5.2.0",
     "wait-port": "^0.2.2",
     "wrap-ansi": "^5.1.0"
   },

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -5,7 +5,6 @@ const httpProxy = require("http-proxy");
 const waitPort = require("wait-port");
 const getPort = require("get-port");
 const chokidar = require("chokidar");
-const stripAnsi = require("strip-ansi")
 const { serveFunctions } = require("../../utils/serve-functions");
 const { serverSettings } = require("../../detect-server");
 const { detectFunctionsBuilder } = require("../../detect-functions-builder");
@@ -159,14 +158,14 @@ function startDevServer(settings, log) {
   const args =
     settings.command === "npm" ? ["run", ...settings.args] : settings.args;
   const ps = execa(settings.command, args, {
-    env: settings.env,
+    env: settings.env
   });
-  ps.stdout.on('data', function(buffer) {
-    process.stdout.write(stripAnsi(buffer.toString('utf8')))
-  })
-  ps.stderr.on('data', function(buffer) {
-    process.stderr.write(stripAnsi(buffer.toString('utf8')))
-  })
+  ps.stdout.on("data", function(buffer) {
+    process.stdout.write(buffer.toString("utf8"));
+  });
+  ps.stderr.on("data", function(buffer) {
+    process.stderr.write(buffer.toString("utf8"));
+  });
   ps.on("close", code => process.exit(code));
   ps.on("SIGINT", process.exit);
   ps.on("SIGTERM", process.exit);
@@ -324,7 +323,8 @@ DevCommand.flags = {
   }),
   port: flags.integer({
     char: "p",
-    description: "port of netlify dev" }),
+    description: "port of netlify dev"
+  }),
   dir: flags.string({
     char: "d",
     description: "dir with static files"

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -158,7 +158,7 @@ function startDevServer(settings, log) {
   const args =
     settings.command === "npm" ? ["run", ...settings.args] : settings.args;
   const ps = execa(settings.command, args, {
-    env: settings.env,
+    env: { ...settings.env, FORCE_COLOR: "true" },
     stdio: ["inherit", "pipe", "pipe"]
   });
   ps.stdout.on("data", function(buffer) {

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -5,6 +5,7 @@ const httpProxy = require("http-proxy");
 const waitPort = require("wait-port");
 const getPort = require("get-port");
 const chokidar = require("chokidar");
+const stripAnsi = require("strip-ansi")
 const { serveFunctions } = require("../../utils/serve-functions");
 const { serverSettings } = require("../../detect-server");
 const { detectFunctionsBuilder } = require("../../detect-functions-builder");
@@ -160,6 +161,12 @@ function startDevServer(settings, log) {
   const ps = execa(settings.command, args, {
     env: settings.env,
   });
+  ps.stdout.on('data', function(buffer) {
+    process.stdout.write(stripAnsi(buffer.toString('utf8')))
+  })
+  ps.stderr.on('data', function(buffer) {
+    process.stderr.write(stripAnsi(buffer.toString('utf8')))
+  })
   ps.on("close", code => process.exit(code));
   ps.on("SIGINT", process.exit);
   ps.on("SIGTERM", process.exit);

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -159,7 +159,6 @@ function startDevServer(settings, log) {
     settings.command === "npm" ? ["run", ...settings.args] : settings.args;
   const ps = execa(settings.command, args, {
     env: settings.env,
-    stdio: "inherit"
   });
   ps.on("close", code => process.exit(code));
   ps.on("SIGINT", process.exit);

--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -158,7 +158,8 @@ function startDevServer(settings, log) {
   const args =
     settings.command === "npm" ? ["run", ...settings.args] : settings.args;
   const ps = execa(settings.command, args, {
-    env: settings.env
+    env: settings.env,
+    stdio: ["inherit", "pipe", "pipe"]
   });
   ps.stdout.on("data", function(buffer) {
     process.stdout.write(buffer.toString("utf8"));


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
`create-react-app` script was using ANSI to clear the screen before we could display our own information. This change disables the handing over of terminal to child script, and buffering output from it. When `create-react-app` detects that it is not attached to a terminal, it does not clear screen.
Fixes: https://github.com/netlify/cli/issues/374
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**

* `npx create-react-app my-new-cra`
* `cd my-new-cra`
* `netlify dev`


Before: 
<img width="842" alt="Screen Shot 2019-07-25 at 2 39 16 AM" src="https://user-images.githubusercontent.com/10067728/61833459-6c28b000-ae85-11e9-84d4-197dd11b3fe4.png">
After:
<img width="682" alt="Screen Shot 2019-07-25 at 2 01 54 AM" src="https://user-images.githubusercontent.com/10067728/61833467-72b72780-ae85-11e9-9f5a-063f77f07dce.png">


**- Description for the changelog**
* Dont handover terminal to child scripts
* Buffer `stdout` and `stderr` from child scripts to terminal

**- A picture of a cute animal (not mandatory but encouraged)**
![baby-seal-29vsgyf](https://user-images.githubusercontent.com/10067728/61832077-020e0c00-ae81-11e9-8c8c-fba56391b803.jpg)
