### PR TITLE
Dev: Fix port flag

### DIFF
--- a/src/detect-server.js
+++ b/src/detect-server.js
@@ -126,13 +126,7 @@ module.exports.serverSettings = async devConfig => {
         tellUser("command")
       ); // if settings.command is empty, its bc no settings matched
     }
-    if (devConfig.port) {
-      settings.proxyPort = devConfig.port || settings.proxyPort;
-      const regexp =
-        devConfig.urlRegexp ||
-        new RegExp(`(http://)([^:]+:)${devConfig.port}(/)?`, "g");
-      settings.urlRegexp = settings.urlRegexp || regexp;
-    }
+    if (devConfig.port) settings.port = devConfig.port;
     settings.dist = devConfig.publish || settings.dist; // dont loudassign if they dont need it
   }
   return settings;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/netlify-dev-plugin/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

The description for `port` flag and its use in the script was conflicting. This change allows you to specify dev server port via `port` flag.

**- Test plan**

* Run `netlify dev --port 8085` in your project dir

**- Description for the changelog**

* Dont use `port` flag for `proxyPort`
* Use `port` flag to specify dev server port

**- A picture of a cute animal (not mandatory but encouraged)**
![Smart-sheep](https://user-images.githubusercontent.com/10067728/62214810-3a50a580-b3bf-11e9-97d6-bbcecfac4b22.jpg)
