### PR TITLE
fix: authorization for sync-schema

### DIFF
--- a/src/functions-templates/js/fauna-graphql/sync-schema.js
+++ b/src/functions-templates/js/fauna-graphql/sync-schema.js
@@ -15,14 +15,14 @@ function createFaunaGraphQL() {
     .toString(); // name of your schema file
 
   // encoded authorization header similar to https://www.npmjs.com/package/request#http-authentication
-  const Authorization = Buffer.from(
+  const token = Buffer.from(
     process.env.FAUNADB_SERVER_SECRET + ":"
   ).toString("base64");
 
   var options = {
     method: "POST",
     body: dataString,
-    headers: { Authorization }
+    headers: { Authorization: `Basic ${token}` }
   };
 
   fetch("https://graphql.fauna.com/import", options)


### PR DESCRIPTION
before: `Invalid authorization header.` when running `sync-schema`.
![Code_qyB2h3o4Ga](https://user-images.githubusercontent.com/30179461/62825062-06873400-bba6-11e9-8924-cd0c948c4c52.png)

